### PR TITLE
Add loader for text price data

### DIFF
--- a/python/mcrunner/__init__.py
+++ b/python/mcrunner/__init__.py
@@ -1,0 +1,4 @@
+from .instruments import *
+from .orders import *
+from .positions import *
+from .strategy import *

--- a/python/mcrunner/instruments/__init__.py
+++ b/python/mcrunner/instruments/__init__.py
@@ -1,0 +1,7 @@
+from .bar import Bar, BarType
+from .bar_series import BarSeries
+from .bars import Bars
+from .loadable_bars import LoadableBars
+from .monitored_bars import MonitoredBars
+from .playable_bars import PlayableBars
+from .file_loader import load_bars_from_file

--- a/python/mcrunner/instruments/bar.py
+++ b/python/mcrunner/instruments/bar.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum, auto
+
+class BarType(Enum):
+    Live = auto()
+    Historic = auto()
+
+@dataclass
+class Bar:
+    Time: datetime = None
+    High: float = 0.0
+    Low: float = 0.0
+    Open: float = 0.0
+    Close: float = 0.0
+    Volume: float = 0.0
+    BarType: BarType = BarType.Historic

--- a/python/mcrunner/instruments/bar_series.py
+++ b/python/mcrunner/instruments/bar_series.py
@@ -1,0 +1,23 @@
+from typing import List
+from .bar import Bar
+
+class BarSeries:
+    def __init__(self, bars: List[Bar], field: str):
+        if bars is None:
+            raise ValueError("bars must not be null")
+        if not hasattr(Bar, field):
+            raise ValueError(f"{field} is not a valid Bar field")
+        self._bars = bars
+        self._field = field
+
+    def __getitem__(self, bars_ago: int):
+        if bars_ago < 0:
+            raise IndexError("Can't look into the future!")
+        index = len(self._bars) - 1 - bars_ago
+        if index < 0:
+            raise IndexError(f"{bars_ago} is too far back! There are only {len(self._bars)} bars")
+        return getattr(self._bars[index], self._field)
+
+    @property
+    def Value(self):
+        return self[0]

--- a/python/mcrunner/instruments/bars.py
+++ b/python/mcrunner/instruments/bars.py
@@ -1,0 +1,46 @@
+from typing import List
+from .bar import Bar
+from .bar_series import BarSeries
+
+class Bars:
+    def __init__(self):
+        self.bars: List[Bar] = []
+        self.reload_bar_series()
+
+    def reload_bar_series(self):
+        self.Close = BarSeries(self.bars, "Close")
+        self.High = BarSeries(self.bars, "High")
+        self.Low = BarSeries(self.bars, "Low")
+        self.Open = BarSeries(self.bars, "Open")
+        self.Time = BarSeries(self.bars, "Time")
+        self.Volume = BarSeries(self.bars, "Volume")
+
+    def to_single_data_stream(self):
+        return [self]
+
+    @property
+    def CurrentBar(self):
+        index = len(self.bars) - 1
+        if index < 0:
+            raise IndexError()
+        return index
+
+    @property
+    def HighValue(self):
+        return self.bars[self.CurrentBar].High
+
+    @property
+    def LowValue(self):
+        return self.bars[self.CurrentBar].Low
+
+    @property
+    def OpenValue(self):
+        return self.bars[self.CurrentBar].Open
+
+    @property
+    def CloseValue(self):
+        return self.bars[self.CurrentBar].Close
+
+    @property
+    def VolumeValue(self):
+        return self.bars[self.CurrentBar].Volume

--- a/python/mcrunner/instruments/file_loader.py
+++ b/python/mcrunner/instruments/file_loader.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import List
+from .bar import Bar
+
+
+def _parse_datetime(date_str: str, time_str: str | None) -> datetime:
+    patterns = ["%Y/%m/%d", "%Y-%m-%d", "%Y%m%d"]
+    if time_str is not None:
+        time_patterns = ["%H:%M", "%H:%M:%S"]
+        for dp in patterns:
+            for tp in time_patterns:
+                try:
+                    return datetime.strptime(f"{date_str} {time_str}", f"{dp} {tp}")
+                except ValueError:
+                    continue
+    else:
+        for dp in patterns:
+            try:
+                return datetime.strptime(date_str, dp)
+            except ValueError:
+                continue
+    return datetime.now()
+
+
+def load_bars_from_file(path: str) -> List[Bar]:
+    bars: List[Bar] = []
+    with open(path, "r", encoding="utf-8-sig") as f:
+        for line in f:
+            line = line.strip()
+            if not line or any(c.isalpha() for c in line.split(',')[0]):
+                # skip header or invalid line
+                continue
+            parts = [p.strip() for p in line.replace('\t', ',').split(',') if p.strip()]
+            if len(parts) < 5:
+                continue
+            if len(parts) >= 7:
+                date_str, time_str = parts[0], parts[1]
+                idx = 2
+            else:
+                date_str, time_str = parts[0], None
+                idx = 1
+            dt = _parse_datetime(date_str, time_str)
+            try:
+                open_p = float(parts[idx]); idx += 1
+                high_p = float(parts[idx]); idx += 1
+                low_p = float(parts[idx]); idx += 1
+                close_p = float(parts[idx]); idx += 1
+            except (ValueError, IndexError):
+                continue
+            volume = float(parts[idx]) if len(parts) > idx else 0.0
+            bars.append(Bar(Time=dt, Open=open_p, High=high_p, Low=low_p, Close=close_p, Volume=volume))
+    return bars

--- a/python/mcrunner/instruments/loadable_bars.py
+++ b/python/mcrunner/instruments/loadable_bars.py
@@ -1,0 +1,7 @@
+from .bars import Bars
+from .bar import Bar
+
+class LoadableBars(Bars):
+    def add_bar(self, bar: Bar):
+        self.bars.append(bar)
+        self.reload_bar_series()

--- a/python/mcrunner/instruments/monitored_bars.py
+++ b/python/mcrunner/instruments/monitored_bars.py
@@ -1,0 +1,19 @@
+from typing import Callable, List
+from .loadable_bars import LoadableBars
+from .bar import Bar
+
+class MonitoredBars(LoadableBars):
+    def __init__(self):
+        super().__init__()
+        self._callbacks: List[Callable[[Bar], None]] = []
+
+    def add_callback(self, cb: Callable[[Bar], None]):
+        self._callbacks.append(cb)
+
+    def add_bar(self, bar: Bar):
+        super().add_bar(bar)
+        for cb in list(self._callbacks):
+            cb(bar)
+
+    def to_single_data_stream(self):
+        return [self]

--- a/python/mcrunner/instruments/playable_bars.py
+++ b/python/mcrunner/instruments/playable_bars.py
@@ -1,0 +1,15 @@
+from typing import Iterable, Callable
+from .bars import Bars
+from .bar import Bar
+
+class PlayableBars(Bars):
+    def __init__(self, bars_to_play: Iterable[Bar]):
+        super().__init__()
+        self.bars_to_play = list(bars_to_play)
+
+    def play(self, action: Callable[[Bar], None]):
+        for bar in self.bars_to_play:
+            self.bars.append(bar)
+            self.reload_bar_series()
+            action(bar)
+        self.bars_to_play = []

--- a/python/mcrunner/orders/__init__.py
+++ b/python/mcrunner/orders/__init__.py
@@ -1,0 +1,14 @@
+from .enums import (
+    EOrderAction,
+    OrderCategory,
+    EExitType,
+    Contracts,
+    OrderExit,
+    SOrderParameters,
+)
+from .order_info import OrderInfo
+from .order_creator import OrderCreator
+from .market_order import MarketOrder
+from .limit_order import LimitOrder
+from .stop_order import StopOrder
+from .stop_limit_order import StopLimitOrder

--- a/python/mcrunner/orders/base_order.py
+++ b/python/mcrunner/orders/base_order.py
@@ -1,0 +1,17 @@
+from typing import Callable, List
+from .enums import SOrderParameters, OrderCategory
+from .order_info import OrderInfo
+
+class BaseOrder:
+    def __init__(self, order_params: SOrderParameters, category: OrderCategory, open_next: bool):
+        self.OrderParams = order_params
+        self.Category = category
+        self.OpenNext = open_next
+        self.callbacks: List[Callable[[OrderInfo], None]] = []
+
+    def subscribe(self, cb: Callable[[OrderInfo], None]):
+        self.callbacks.append(cb)
+
+    def _trigger(self, info: OrderInfo):
+        for cb in list(self.callbacks):
+            cb(info)

--- a/python/mcrunner/orders/enums.py
+++ b/python/mcrunner/orders/enums.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+class EOrderAction(Enum):
+    Buy = auto()
+    Sell = auto()
+    SellShort = auto()
+    BuyToCover = auto()
+
+class OrderCategory(Enum):
+    Market = auto()
+    Limit = auto()
+    Stop = auto()
+    StopLimit = auto()
+
+class EExitType(Enum):
+    All = auto()
+
+@dataclass
+class Contracts:
+    contract: int = 100
+    is_user_specified: bool = False
+
+    @staticmethod
+    def Default():
+        return Contracts()
+
+    @staticmethod
+    def CreateUserSpecified(size: int):
+        return Contracts(contract=size, is_user_specified=True)
+
+@dataclass
+class OrderExit:
+    ExitType: EExitType = EExitType.All
+
+@dataclass
+class SOrderParameters:
+    contracts: Contracts = field(default_factory=Contracts.Default)
+    action: EOrderAction = EOrderAction.Buy
+    exit_type_info: OrderExit = field(default_factory=OrderExit)
+    name: str = ""
+    lots: Contracts = field(default_factory=Contracts.Default)

--- a/python/mcrunner/orders/limit_order.py
+++ b/python/mcrunner/orders/limit_order.py
@@ -1,0 +1,22 @@
+from .enums import SOrderParameters, OrderCategory
+from .order_info import OrderInfo
+from .base_order import BaseOrder
+
+class LimitOrder(BaseOrder):
+    def __init__(self, order_params: SOrderParameters, open_next: bool = False):
+        super().__init__(order_params, OrderCategory.Limit, open_next)
+
+    def send(self, price: float, num_lots: int = 0):
+        if price <= 0:
+            raise ValueError("price must be > 0")
+        if num_lots < 0:
+            raise ValueError("numLots must be >= 0")
+        size = self.OrderParams.contracts.contract if not self.OrderParams.contracts.is_user_specified else num_lots or self.OrderParams.contracts.contract
+        info = OrderInfo(
+            Order=self,
+            OrderAction=self.OrderParams.action,
+            OrderExit=self.OrderParams.exit_type_info,
+            Price=price,
+            Size=size,
+        )
+        self._trigger(info)

--- a/python/mcrunner/orders/market_order.py
+++ b/python/mcrunner/orders/market_order.py
@@ -1,0 +1,19 @@
+from .enums import SOrderParameters, OrderCategory, EOrderAction
+from .order_info import OrderInfo
+from .base_order import BaseOrder
+
+class MarketOrder(BaseOrder):
+    def __init__(self, order_params: SOrderParameters, open_next: bool = False):
+        super().__init__(order_params, OrderCategory.Market, open_next)
+
+    def send(self, num_lots: int = 0):
+        if num_lots < 0:
+            raise ValueError("numLots must be >= 0")
+        size = self.OrderParams.contracts.contract if not self.OrderParams.contracts.is_user_specified else num_lots or self.OrderParams.contracts.contract
+        info = OrderInfo(
+            Order=self,
+            OrderAction=self.OrderParams.action,
+            OrderExit=self.OrderParams.exit_type_info,
+            Size=size
+        )
+        self._trigger(info)

--- a/python/mcrunner/orders/order_creator.py
+++ b/python/mcrunner/orders/order_creator.py
@@ -1,0 +1,31 @@
+from typing import Callable
+from .enums import SOrderParameters
+from .market_order import MarketOrder
+from .limit_order import LimitOrder
+from .stop_order import StopOrder
+from .stop_limit_order import StopLimitOrder
+from .order_info import OrderInfo
+
+class OrderCreator:
+    def __init__(self):
+        self.order_sent: Callable[[OrderInfo], None] | None = None
+
+    def _wire(self, order):
+        if self.order_sent:
+            order.subscribe(self.order_sent)
+        return order
+
+    def limit(self, order_params: SOrderParameters):
+        return self._wire(LimitOrder(order_params, True))
+
+    def market_next_bar(self, order_params: SOrderParameters):
+        return self._wire(MarketOrder(order_params, True))
+
+    def market_this_bar(self, order_params: SOrderParameters):
+        return self._wire(MarketOrder(order_params, False))
+
+    def stop(self, order_params: SOrderParameters):
+        return self._wire(StopOrder(order_params, True))
+
+    def stop_limit(self, order_params: SOrderParameters):
+        return self._wire(StopLimitOrder(order_params, True))

--- a/python/mcrunner/orders/order_info.py
+++ b/python/mcrunner/orders/order_info.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+from .enums import EOrderAction, OrderExit
+
+@dataclass
+class OrderInfo:
+    ConditionPrice: float = 0.0
+    Price: float = 0.0
+    Size: float = 0.0
+    OrderAction: EOrderAction = EOrderAction.Buy
+    Order: "BaseOrder" = None
+    OrderExit: OrderExit = field(default_factory=OrderExit)

--- a/python/mcrunner/orders/stop_limit_order.py
+++ b/python/mcrunner/orders/stop_limit_order.py
@@ -1,0 +1,23 @@
+from .enums import SOrderParameters, OrderCategory
+from .order_info import OrderInfo
+from .base_order import BaseOrder
+
+class StopLimitOrder(BaseOrder):
+    def __init__(self, order_params: SOrderParameters, open_next: bool = False):
+        super().__init__(order_params, OrderCategory.StopLimit, open_next)
+
+    def send(self, price: float, limit_price: float, num_lots: int = 0):
+        if price <= 0 or limit_price <= 0:
+            raise ValueError("price must be > 0")
+        if num_lots < 0:
+            raise ValueError("numLots must be >= 0")
+        size = self.OrderParams.contracts.contract if not self.OrderParams.contracts.is_user_specified else num_lots or self.OrderParams.contracts.contract
+        info = OrderInfo(
+            ConditionPrice=price,
+            Price=limit_price,
+            Order=self,
+            OrderAction=self.OrderParams.action,
+            OrderExit=self.OrderParams.exit_type_info,
+            Size=size,
+        )
+        self._trigger(info)

--- a/python/mcrunner/orders/stop_order.py
+++ b/python/mcrunner/orders/stop_order.py
@@ -1,0 +1,22 @@
+from .enums import SOrderParameters, OrderCategory
+from .order_info import OrderInfo
+from .base_order import BaseOrder
+
+class StopOrder(BaseOrder):
+    def __init__(self, order_params: SOrderParameters, open_next: bool = False):
+        super().__init__(order_params, OrderCategory.Stop, open_next)
+
+    def send(self, price: float, num_lots: int = 0):
+        if price <= 0:
+            raise ValueError("price must be > 0")
+        if num_lots < 0:
+            raise ValueError("numLots must be >= 0")
+        size = self.OrderParams.contracts.contract if not self.OrderParams.contracts.is_user_specified else num_lots or self.OrderParams.contracts.contract
+        info = OrderInfo(
+            ConditionPrice=price,
+            Order=self,
+            OrderAction=self.OrderParams.action,
+            OrderExit=self.OrderParams.exit_type_info,
+            Size=size,
+        )
+        self._trigger(info)

--- a/python/mcrunner/positions/__init__.py
+++ b/python/mcrunner/positions/__init__.py
@@ -1,0 +1,3 @@
+from .position_info import PositionInfo
+from .long_position import LongPosition, InvalidOrderException as LongInvalid
+from .short_position import ShortPosition, InvalidOrderException as ShortInvalid

--- a/python/mcrunner/positions/long_position.py
+++ b/python/mcrunner/positions/long_position.py
@@ -1,0 +1,33 @@
+from typing import List
+from ..orders import OrderInfo, EOrderAction, OrderExit, EExitType
+from .position_info import PositionInfo
+
+class InvalidOrderException(Exception):
+    pass
+
+class LongPosition:
+    def __init__(self):
+        self.positions: List[PositionInfo] = []
+
+    @property
+    def Size(self):
+        return sum(p.Size for p in self.positions)
+
+    def validate_order(self, order: OrderInfo):
+        if order.OrderAction == EOrderAction.Buy:
+            return
+        if order.OrderAction == EOrderAction.Sell:
+            if not self.positions:
+                raise InvalidOrderException("Can't close position before opening one!")
+            if order.OrderExit.ExitType != EExitType.All:
+                pass
+        else:
+            raise InvalidOrderException("Long orders only!")
+
+    def update_position(self, order: OrderInfo):
+        if order.OrderAction == EOrderAction.Buy:
+            self.positions.append(PositionInfo(order.Size))
+        elif order.OrderAction == EOrderAction.Sell:
+            self.positions.clear()
+        else:
+            raise InvalidOrderException("Unsupported OrderAction")

--- a/python/mcrunner/positions/position_info.py
+++ b/python/mcrunner/positions/position_info.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+@dataclass
+class PositionInfo:
+    Size: float

--- a/python/mcrunner/positions/short_position.py
+++ b/python/mcrunner/positions/short_position.py
@@ -1,0 +1,33 @@
+from typing import List
+from ..orders import OrderInfo, EOrderAction, OrderExit, EExitType
+from .position_info import PositionInfo
+
+class InvalidOrderException(Exception):
+    pass
+
+class ShortPosition:
+    def __init__(self):
+        self.positions: List[PositionInfo] = []
+
+    @property
+    def Size(self):
+        return sum(p.Size for p in self.positions)
+
+    def validate_order(self, order: OrderInfo):
+        if order.OrderAction == EOrderAction.SellShort:
+            return
+        if order.OrderAction == EOrderAction.BuyToCover:
+            if not self.positions:
+                raise InvalidOrderException("Can't close position before opening one!")
+            if order.OrderExit.ExitType != EExitType.All:
+                pass
+        else:
+            raise InvalidOrderException("Short orders only!")
+
+    def update_position(self, order: OrderInfo):
+        if order.OrderAction == EOrderAction.SellShort:
+            self.positions.append(PositionInfo(order.Size))
+        elif order.OrderAction == EOrderAction.BuyToCover:
+            self.positions.clear()
+        else:
+            raise InvalidOrderException("Unsupported OrderAction")

--- a/python/mcrunner/strategy/__init__.py
+++ b/python/mcrunner/strategy/__init__.py
@@ -1,0 +1,5 @@
+from .strategy_runner import StrategyRunner
+from .strategy_backtester import StrategyBacktester
+from .strategy_manager import StrategyManager
+from .strategy_performance import StrategyPerformance
+from .trade import ExecutedTrade

--- a/python/mcrunner/strategy/strategy_backtester.py
+++ b/python/mcrunner/strategy/strategy_backtester.py
@@ -1,0 +1,29 @@
+from typing import Iterable, Callable
+from ..instruments import Bar, PlayableBars
+from ..orders import OrderCreator, OrderInfo
+from .strategy_runner import StrategyRunner
+from .strategy_manager import StrategyManager
+from .strategy_performance import StrategyPerformance
+
+class StrategyBacktester:
+    def __init__(self, strategy_cls, bars: Iterable[Bar]):
+        self.order_creator = OrderCreator()
+        self.manager = StrategyManager(self.order_creator)
+        self.strategy_info = self.manager.StrategyInfo
+        self.playable_bars = PlayableBars(bars)
+        self.runner = StrategyRunner(strategy_cls,
+                                     bars_data=self.playable_bars.to_single_data_stream(),
+                                     order_creator=self.order_creator,
+                                     strategy_info=self.strategy_info)
+        self.Strategy = self.runner.Strategy
+
+    def backtest(self, action: Callable[[Bar], None] | None = None):
+        self.runner.create()
+        self.runner.start_calc()
+        def callback(bar):
+            self.runner.calc_bar()
+            index = self.runner.Strategy.Bars.CurrentBar
+            self.manager.trigger_orders(bar, index)
+            if action:
+                action(bar)
+        self.playable_bars.play(callback)

--- a/python/mcrunner/strategy/strategy_manager.py
+++ b/python/mcrunner/strategy/strategy_manager.py
@@ -1,0 +1,72 @@
+from typing import List, Callable
+from ..orders import (
+    OrderCreator,
+    OrderInfo,
+    EOrderAction,
+    OrderCategory,
+)
+from ..positions import LongPosition, ShortPosition
+from .strategy_performance import StrategyPerformance
+from .trade import ExecutedTrade
+
+class StrategyManager:
+    def __init__(self, order_creator: OrderCreator):
+        self._long = LongPosition()
+        self._short = ShortPosition()
+        self.StrategyInfo = StrategyPerformance()
+        self.ExecutedOrders: List[ExecutedTrade] = []
+        self._untriggered: List[OrderInfo] = []
+        self._prev_submitted: List[OrderInfo] = []
+        self.OrderValidated: List[Callable[[OrderInfo], None]] = []
+        self.OrderCanceled: List[Callable[[OrderInfo], None]] = []
+        order_creator.order_sent = self.on_order_sent
+
+    def on_order_sent(self, order: OrderInfo):
+        self.validate_order(order)
+        if order not in self._untriggered:
+            self._untriggered.append(order)
+            for cb in self.OrderValidated:
+                cb(order)
+
+    def validate_order(self, order: OrderInfo):
+        if order.OrderAction in (EOrderAction.Buy, EOrderAction.Sell):
+            self._long.validate_order(order)
+        else:
+            self._short.validate_order(order)
+
+    def trigger_orders(self, bar, index: int):
+        triggered = []
+        for order in list(self._untriggered):
+            if order.Order.Category == OrderCategory.Market:
+                triggered.append(order)
+            elif order.Order.Category in (OrderCategory.Limit, OrderCategory.Stop, OrderCategory.StopLimit):
+                price = order.ConditionPrice or order.Price
+                if order.OrderAction in (EOrderAction.Buy, EOrderAction.BuyToCover):
+                    if price >= getattr(bar, 'Low', 0):
+                        triggered.append(order)
+                else:
+                    if price <= getattr(bar, 'High', 0):
+                        triggered.append(order)
+        for order in triggered:
+            self.on_order_triggered(order, bar, index)
+
+        for order in list(self._prev_submitted):
+            if order not in self._untriggered:
+                for cb in self.OrderCanceled:
+                    cb(order)
+        self._prev_submitted = self._untriggered
+        self._untriggered = []
+
+    def on_order_triggered(self, order: OrderInfo, bar, index: int):
+        if order.Price <= 0:
+            order.Price = getattr(bar, 'Close', 0)
+        self.ExecutedOrders.append(ExecutedTrade(index, order.OrderAction, order.Price, order.Size))
+        if order.OrderAction in (EOrderAction.Buy, EOrderAction.Sell):
+            self._long.update_position(order)
+        else:
+            self._short.update_position(order)
+        self.StrategyInfo.MarketPosition = int(self._long.Size - self._short.Size)
+        if order in self._untriggered:
+            self._untriggered.remove(order)
+        if order in self._prev_submitted:
+            self._prev_submitted.remove(order)

--- a/python/mcrunner/strategy/strategy_performance.py
+++ b/python/mcrunner/strategy/strategy_performance.py
@@ -1,0 +1,13 @@
+class StrategyPerformance:
+    def __init__(self):
+        self.MarketPosition = 0
+        self.market_position_at_broker = 0
+
+    @property
+    def MarketPositionAtBroker(self):
+        return int(self.market_position_at_broker)
+
+    def update_market_position_at_broker(self, change: float):
+        self.market_position_at_broker += change
+
+    # SetPlotValue/GetPlotValue not implemented

--- a/python/mcrunner/strategy/strategy_runner.py
+++ b/python/mcrunner/strategy/strategy_runner.py
@@ -1,0 +1,30 @@
+from typing import Iterable
+from ..instruments import Bars
+from ..orders import OrderCreator
+from .strategy_performance import StrategyPerformance
+
+class StrategyRunner:
+    def __init__(self, strategy_cls, bars_data: Iterable[Bars] = None,
+                 order_creator: OrderCreator = None,
+                 strategy_info: StrategyPerformance = None):
+        self.Strategy = strategy_cls()
+        self._bars = list(bars_data or [])
+        self._order_creator = order_creator or OrderCreator()
+        self._strategy_info = strategy_info or StrategyPerformance()
+        # manager is expected to be handled by caller
+        # supply strategy with required attributes
+        self.Strategy.Bars = self._bars[0] if self._bars else Bars()
+        self.Strategy.OrderCreator = self._order_creator
+        self.Strategy.StrategyInfo = self._strategy_info
+
+    def create(self):
+        if hasattr(self.Strategy, 'create'):
+            self.Strategy.create()
+
+    def start_calc(self):
+        if hasattr(self.Strategy, 'start_calc'):
+            self.Strategy.start_calc()
+
+    def calc_bar(self):
+        if hasattr(self.Strategy, 'calc_bar'):
+            self.Strategy.calc_bar()

--- a/python/mcrunner/strategy/trade.py
+++ b/python/mcrunner/strategy/trade.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from ..orders.enums import EOrderAction
+
+@dataclass
+class ExecutedTrade:
+    bar_index: int
+    action: EOrderAction
+    price: float
+    size: float

--- a/python/price_breakouts.py
+++ b/python/price_breakouts.py
@@ -1,0 +1,94 @@
+import random
+from typing import List, Tuple
+from mcrunner.instruments import load_bars_from_file
+
+
+def exponential_moving_average(data: List[float], length: int) -> List[float]:
+    ema = []
+    alpha = 2 / (length + 1)
+    for i, value in enumerate(data):
+        if i == 0:
+            ema.append(value)
+        else:
+            ema.append(alpha * value + (1 - alpha) * ema[i - 1])
+    return ema
+
+
+def rolling_max(data: List[float], window: int) -> List[float]:
+    result = []
+    for i in range(len(data)):
+        if i == 0:
+            result.append(data[0])
+        elif i < window:
+            result.append(max(data[:i]))
+        else:
+            result.append(max(data[i - window:i]))
+    return result
+
+
+def rolling_min(data: List[float], window: int) -> List[float]:
+    result = []
+    for i in range(len(data)):
+        if i == 0:
+            result.append(data[0])
+        elif i < window:
+            result.append(min(data[:i]))
+        else:
+            result.append(min(data[i - window:i]))
+    return result
+
+
+def price_breakouts(close: List[float], ema_length: int = 50, lookback_period: int = 10) -> List[Tuple[str, int, float]]:
+    ema = exponential_moving_average(close, ema_length)
+    highest = rolling_max(close[:-1], lookback_period) + [max(close[-lookback_period:])]
+    lowest = rolling_min(close[:-1], lookback_period) + [min(close[-lookback_period:])]
+
+    position = 0
+    trades = []
+    for i in range(1, len(close)):
+        c = close[i]
+        c_prev = close[i - 1]
+        hi = highest[i]
+        hi_prev = highest[i - 1]
+        lo = lowest[i]
+        lo_prev = lowest[i - 1]
+        e = ema[i]
+        e_prev = ema[i - 1]
+
+        if position == 0:
+            if c > hi and c_prev < hi_prev:
+                position = 1
+                trades.append(('buy', i, c))
+            elif c < lo and c_prev > lo_prev:
+                position = -1
+                trades.append(('sell_short', i, c))
+        elif position == 1:
+            if c < e and c_prev >= e_prev:
+                position = 0
+                trades.append(('exit_long', i, c))
+        elif position == -1:
+            if c > e and c_prev <= e_prev:
+                position = 0
+                trades.append(('exit_short', i, c))
+    return trades
+
+
+def example_run(path: str = "MCRunner/Instruments/data/2330 1 Day.txt"):
+    try:
+        bars = load_bars_from_file(path)
+        close_prices = [b.Close for b in bars]
+    except FileNotFoundError:
+        random.seed(0)
+        close_prices = []
+        price = 100.0
+        for _ in range(200):
+            price += random.gauss(0, 1)
+            close_prices.append(price)
+
+    trades = price_breakouts(close_prices)
+    for t in trades:
+        print(t)
+
+
+if __name__ == "__main__":
+    example_run()

--- a/python/price_breakouts_strategy.py
+++ b/python/price_breakouts_strategy.py
@@ -1,0 +1,98 @@
+import random
+from mcrunner import (
+    Bar, StrategyBacktester,
+    SOrderParameters, Contracts, EOrderAction,
+    load_bars_from_file
+)
+
+class PriceBreakouts:
+    def __init__(self):
+        self.EMALength = 50
+        self.LookbackPeriod = 10
+        self.OrderCreator = None
+        self.Bars = None
+        self.StrategyInfo = None
+        self.ema_values = []
+        self.highest = []
+        self.lowest = []
+
+    def create(self):
+        self.enter_long = self.OrderCreator.market_next_bar(
+            SOrderParameters(Contracts.Default(), EOrderAction.Buy))
+        self.enter_short = self.OrderCreator.market_next_bar(
+            SOrderParameters(Contracts.Default(), EOrderAction.SellShort))
+        self.exit_long = self.OrderCreator.market_next_bar(
+            SOrderParameters(Contracts.Default(), EOrderAction.Sell))
+        self.exit_short = self.OrderCreator.market_next_bar(
+            SOrderParameters(Contracts.Default(), EOrderAction.BuyToCover))
+
+    def start_calc(self):
+        pass
+
+    def calc_bar(self):
+        close = self.Bars.CloseValue
+        closes = [b.Close for b in self.Bars.bars]
+        if not self.ema_values:
+            self.ema_values.append(close)
+        else:
+            k = 2/(self.EMALength+1)
+            self.ema_values.append(k*close + (1-k)*self.ema_values[-1])
+        prev = closes[:-1]
+        lookback = prev[-self.LookbackPeriod:] if prev else []
+        self.highest.append(max(lookback) if lookback else close)
+        self.lowest.append(min(lookback) if lookback else close)
+        ema = self.ema_values[-1]
+
+        if self.StrategyInfo.MarketPosition == 0 and len(closes) > 1:
+            prev_high = self.highest[-2]
+            prev_low = self.lowest[-2]
+            if close > self.highest[-1] and closes[-2] < prev_high:
+                self.enter_long.send()
+            elif close < self.lowest[-1] and closes[-2] > prev_low:
+                self.enter_short.send()
+        elif self.StrategyInfo.MarketPosition > 0 and len(closes) > 1:
+            prev_ema = self.ema_values[-2]
+            if close < ema and closes[-2] >= prev_ema:
+                self.exit_long.send()
+        elif self.StrategyInfo.MarketPosition < 0 and len(closes) > 1:
+            prev_ema = self.ema_values[-2]
+            if close > ema and closes[-2] <= prev_ema:
+                self.exit_short.send()
+
+
+def example(path: str = "MCRunner/Instruments/data/2330 1 Day.txt"):
+    try:
+        bars = load_bars_from_file(path)
+    except FileNotFoundError:
+        random.seed(0)
+        bars = []
+        price = 100.0
+        for _ in range(200):
+            price += random.gauss(0, 1)
+            bars.append(Bar(Open=price, High=price+1, Low=price-1, Close=price, Volume=0))
+
+    tester = StrategyBacktester(PriceBreakouts, bars)
+    tester.backtest()
+    print("Final Market Position", tester.strategy_info.MarketPosition)
+    orders = tester.manager.ExecutedOrders
+    position = None
+    entry = None
+    for o in orders:
+        print(f"bar {o.bar_index}: {o.action.name} at {o.price:.2f}")
+        if o.action == EOrderAction.Buy:
+            position = 'long'
+            entry = o
+        elif o.action == EOrderAction.SellShort:
+            position = 'short'
+            entry = o
+        elif o.action == EOrderAction.Sell and position == 'long':
+            pnl = o.price - entry.price
+            print(f" exit long pnl={pnl:.2f}")
+            position = None
+        elif o.action == EOrderAction.BuyToCover and position == 'short':
+            pnl = entry.price - o.price
+            print(f" exit short pnl={pnl:.2f}")
+            position = None
+
+if __name__ == "__main__":
+    example()


### PR DESCRIPTION
## Summary
- implement `load_bars_from_file` for reading bar data from text files
- expose the loader from `mcrunner.instruments`
- make the price breakouts examples try to load `2330 1 Day.txt` and fall back to random data

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=python python3 python/price_breakouts.py | head -n 5`
- `PYTHONPATH=python python3 python/price_breakouts_strategy.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68429947c1fc83238c70bb88df1fb656